### PR TITLE
Validations rules are now extended with (not replaced by) user options

### DIFF
--- a/js/strength-meter.js
+++ b/js/strength-meter.js
@@ -215,6 +215,7 @@
         $.each(options, function (key, value) {
             self[key] = value;
         });
+        self.rules = $.extend({}, $.fn.strength.defaults.rules, self.rules);
         self.$element = $(element);
         self.verdicts = self.generateVerdicts();
         self.setDefault('toggleClass', 'kv-toggle');


### PR DESCRIPTION
Allows user to pass only the `rules` properties they wish to change (previously, you needed to pass **all** rules because your `rules` object would _replace_ the default rules, causing errors (typically manifesting as a strength rating of 'NaN%') during validation).