### PR TITLE
Update Spanish Translations

### DIFF
--- a/js/locales/strength-meter-es.js
+++ b/js/locales/strength-meter-es.js
@@ -6,7 +6,7 @@
 (function ($) {
     "use strict";
 
-    $.extend($.fn.strength.defaults, {
+    $.fn.strengthLocales['es'] = {
         toggleTitle: 'Mostrar / Ocultar contraseña',
         verdictTitles: {
             0: 'Muy corta',
@@ -16,5 +16,5 @@
             4: 'Fuerte',
             5: 'Muy Fuerte'
         }
-    });
+    };
 })(jQuery);


### PR DESCRIPTION
Like the other js languages, because kartik-v / yii2-password does not work in Spanish and this solution work.

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ X ] Translation

## Changes
The following changes were made

-The change is the same as that of the other languages

## Related Issues
If this is related to an existing ticket, include a link to it as well.
https://github.com/kartik-v/yii2-password/issues/46