### PR TITLE
Updated CSS for strength meter to relative position.

### DIFF
--- a/css/strength-meter.css
+++ b/css/strength-meter.css
@@ -45,7 +45,7 @@
 
 .kv-scorebar {
     background: url(../img/bg_strength_gradient.jpg) no-repeat 0 0;
-    position: absolute;
+    position: relative;
     width: 98px;
     height: 14px;
     z-index: 0;
@@ -55,10 +55,11 @@
 .kv-score {
     font-size: 12px;
     line-height: 13px;
-    position: absolute;
+    position: relative;
     width: 98px;
     z-index: 10;
     border-radius: 2px;
+    bottom: 13px;
 }
 
 .kv-score-0, .kv-score-1, .kv-score-5 {


### PR DESCRIPTION
## Scope
This pull request includes a

- [X ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Updated .kvscorebar and .kvscore for relative position. 
- Added bottom: 13px to .kvscore. This allows for scrolling of the page. With the prior absolute position set. This caused issues with scrolling pages. 
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.